### PR TITLE
Fix: Correct modal window behavior

### DIFF
--- a/main/static/main/css/style.css
+++ b/main/static/main/css/style.css
@@ -401,7 +401,7 @@ footer {
 }
 
 .custom-modal.hidden {
-  display: none;
+  display: none !important;
 }
 
 /* === MODAL CONTENT === */

--- a/main/static/main/js/script.js
+++ b/main/static/main/js/script.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const modal = document.getElementById('modal');
   const modalBody = document.getElementById('modal-body');
-  const closeButton = document.querySelector('.close-button');
+  const closeButton = document.querySelector('.modal-close');
   const serviceCards = document.querySelectorAll('.service-card');
 
   // Объект с прайсами для каждой услуги
@@ -44,17 +44,17 @@ document.addEventListener('DOMContentLoaded', () => {
     card.addEventListener('click', () => {
       const service = card.getAttribute('data-service');
       const content = priceList[service] || '<p>Прайс отсутствует</p>';
-      openModal(content);
+      openModal(card.querySelector('p').textContent, content);
     });
   });
 
   // Обработчик клика на кнопку закрытия
-  closeButton.addEventListener('click', closeModal);
+  closeButton.addEventListener('click', () => closeModal('modal'));
 
   // Закрытие модального окна при клике вне его содержимого
   window.addEventListener('click', (event) => {
     if (event.target === modal) {
-      closeModal();
+      closeModal('modal');
     }
   });
 });

--- a/main/templates/main/base.html
+++ b/main/templates/main/base.html
@@ -77,9 +77,9 @@
 
     <!-- Модальное окно -->
 <div id="modal" class="custom-modal hidden">
-  <div class="modal-overlay" onclick="closeModal('modal')"></div>
+  <div class="modal-overlay"></div>
   <div class="custom-modal-content animate-fade-in">
-    <button class="modal-close" onclick="closeModal('modal')">&times;</button>
+    <button class="modal-close">&times;</button>
     <h5 class="modal-title" id="modalTitle">Titre du service</h5>
     <div id="modal-body" class="modal-table-container">
       <!-- Прайс подгружается сюда -->


### PR DESCRIPTION
This commit addresses issues with the modal window functionality:

- Ensures the `openModal` function is called with both title and content.
- Corrects the JavaScript event listener for the close button to use the correct class (`.modal-close`) and to call `closeModal` with the modal's ID.
- Passes the modal ID to `closeModal` in the window click event listener.
- Removes redundant `onclick` attributes from the HTML, centralizing close logic in JavaScript.

These changes should ensure that the modal opens as a pop-up, displays the correct content, and closes reliably via the close button or by clicking the overlay.